### PR TITLE
Inherit fork-base parent POM version

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -218,6 +218,10 @@
               <token>%VERSION%</token>
               <value>${project.version}</value>
             </replacement>
+            <replacement>
+              <token>%GOOGLE_VERSION%</token>
+              <value>${parent.version}</value>
+            </replacement>
           </replacements>
         </configuration>
       </plugin>

--- a/core/src/main/java/com/google/googlejavaformat/java/GoogleJavaFormatVersion.java.template
+++ b/core/src/main/java/com/google/googlejavaformat/java/GoogleJavaFormatVersion.java.template
@@ -21,4 +21,8 @@ class GoogleJavaFormatVersion {
   static String version() {
     return "%VERSION%";
   }
+
+  static String googleVersion() {
+    return "%GOOGLE_VERSION%";
+  }
 }

--- a/core/src/main/java/com/google/googlejavaformat/java/Main.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/Main.java
@@ -40,8 +40,10 @@ public final class Main {
   private static final String STDIN_FILENAME = "<stdin>";
 
   static final String versionString() {
-    return "sg-java-format: Version " + GoogleJavaFormatVersion.version()
-        + ", forked from\ngoogle-java-format: Version 1.6";
+    return "sg-java-format: Version "
+        + GoogleJavaFormatVersion.version()
+        + ", forked from\ngoogle-java-format: Version "
+        + GoogleJavaFormatVersion.googleVersion();
   }
 
   private final PrintWriter outWriter;


### PR DESCRIPTION
The upstream parent POM version doesn't seem to be super well maintained
but it's the closest thing we have to communicate the fork-base at a
high level. Propagate the parent POM version into the generated version
file, like the artifact POM version which has different since the fork.